### PR TITLE
Glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [0.4.0] - 2019-06-01
+## [0.5.0] - 2019-06-02
+
+### Meta
+
+- branch: glitch
+
+### Added
+
+- App.vue: Update url data prop
+
+## [0.4.0] - 2019-06-02
 
 ### Meta
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-web-front-end",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-web-front-end",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Front end source code for the TCAL 2019 workshop, Build a Front End! Build a Back End!: A guided hands-on tour of modern web development tools and concepts.",
   "main": "src/index.html",
   "scripts": {

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -13,7 +13,7 @@ import TheDataGrid from "./TheDataGrid.vue";
 export default {
   data() {
     return {
-      url: "http://localhost:2600/swapi/",
+      url: "https://modern-web-back-end.glitch.me/swapi/",
       resourceTitle: "",
       swapiPayload: {}
     };


### PR DESCRIPTION
This PR swaps out the hardcoded lochcalhost back end server url with the newly deployed back end on glitch, https://modern-web-back-end.glitch.me/.

Closes #12 