### PR TITLE
Flex item data grid width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.6.1] - 2019-06-04
+
+### Meta
+
+- branch: flex-item-data-grid-width
+
+### Added
+
+- TheDataGrid.vue: max-width of 100% via `.col-12` to force the size of the flex item
+
 ## [0.6.0] - 2019-06-03
 
 ### Meta

--- a/src/components/TheDataGrid.vue
+++ b/src/components/TheDataGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="container">
+  <section class="container col-12">
     <h2 class="white">{{ resourceTitle }}</h2>
     <ol class="list-reset grid-container">
       <li


### PR DESCRIPTION
This PR adds `width:100%` style to the root element in TheDataGrid, to appease the flex-item layout.

- Thanks to the solution in a [previous commit ](#17 5923da9e4d)
- closes #17 